### PR TITLE
Fixes to the configuration object

### DIFF
--- a/postgresql.html
+++ b/postgresql.html
@@ -56,7 +56,7 @@
 					<i class="fa fa-lock"></i>
 					<span data-i18n="postgresql.label.password"></span>
 				</label>
-				<input type="text" id="node-config-input-password" data-i18n="[placeholder]postgresql.placeholder.password" style="width: 80%;" />
+				<input type="password" id="node-config-input-password" data-i18n="[placeholder]postgresql.placeholder.password" style="width: 80%;" />
 				<input type="hidden" id="node-config-input-passwordFieldType" />
 			</div>
 		</div>

--- a/postgresql.html
+++ b/postgresql.html
@@ -56,7 +56,7 @@
 					<i class="fa fa-lock"></i>
 					<span data-i18n="postgresql.label.password"></span>
 				</label>
-				<input type="password" id="node-config-input-password" data-i18n="[placeholder]postgresql.placeholder.password" style="width: 80%;" />
+				<input type="text" id="node-config-input-password" data-i18n="[placeholder]postgresql.placeholder.password" style="width: 80%;" />
 				<input type="hidden" id="node-config-input-passwordFieldType" />
 			</div>
 		</div>
@@ -225,15 +225,6 @@
 					default: 'str',
 					types: ['str', 'flow', 'global', 'env'],
 					typeField: $('#node-config-input-passwordFieldType'),
-				})
-				.on('change', function (type, value) {
-					const e = $(this);
-					const kind = value === true ? e.typedInput('type') : value;
-					if (kind === 'str') {
-						e.attr('type', 'password');
-					} else {
-						e.attr('type', 'text');
-					}
 				});
 			$('#node-config-input-max').typedInput({
 				default: 'num',

--- a/postgresql.html
+++ b/postgresql.html
@@ -107,70 +107,60 @@
 			},
 			host: {
 				value: '127.0.0.1',
-				required: true,
 			},
 			hostFieldType: {
 				value: 'str',
 			},
 			port: {
 				value: 5432,
-				required: true,
 			},
 			portFieldType: {
 				value: 'num',
 			},
 			database: {
 				value: 'postgres',
-				required: true,
 			},
 			databaseFieldType: {
 				value: 'str',
 			},
 			ssl: {
 				value: false,
-				required: true,
 			},
 			sslFieldType: {
 				value: 'bool',
 			},
 			max: {
 				value: 10,
-				required: true,
 			},
 			maxFieldType: {
 				value: 'num',
 			},
 			min: {
 				value: 1,
-				required: true,
 			},
 			minFieldType: {
 				value: 'num',
 			},
 			idle: {
 				value: 1000,
-				required: true,
 			},
 			idleFieldType: {
 				value: 'num',
 			},
 			connectionTimeout: {
 				value: 10000,
-				required: true,
 			},
 			connectionTimeoutFieldType: {
 				value: 'num',
 			},
 			user: {
 				value: '',
-				required: true,
 			},
 			userFieldType: {
 				value: 'str',
 			},
 			password: {
 				value: '',
-				required: true,
 			},
 			passwordFieldType: {
 				value: 'str',

--- a/postgresql.js
+++ b/postgresql.js
@@ -42,6 +42,8 @@ module.exports = function (RED) {
 				return parseInt(value);
 			case 'bool':
 				return JSON.parse(value);
+			case 'env':
+				return process.env[value];
 			default:
 				return value;
 		}


### PR DESCRIPTION
Thanks for a useful library.

I'm attaching three independent commits in this PR.

6dcb8f9
This commit fixes reading of environment variables. Previously no environment variables were read, it just wasn't implemented even if it appeared in settings that you could have some connection options refer to environment variable names.

8096dd8
I've removed `required: true` from all connection options fields. They all feed into [pg.Pool](https://node-postgres.com/api/pool) which then internally feeds into [pg.Client](https://node-postgres.com/api/client) and they are all optional as far as the underlying pg library is concerned. For example I don't use a password at all to connect to my Postgres DB and that works just fine, so why is it required to set a password at all? This commit fixes that.

36b56ff
This removes swapping the input attribute `type` to/from `password` and `text` because it doesn't work well. This is how it looks in my installation of node-red `v2.0.5`:

![image](https://user-images.githubusercontent.com/41344/134124812-76e33172-782b-4af8-8da7-064adbfc764f.png)

It's quite confusing, and while I understand why this was added in the first place the existing implementation just doesn't work and this commit removes it.