### PR TITLE
Dynamic PostgreSQL client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,31 @@ msg.params = [ msg.id ];
 SELECT * FROM table WHERE id = $1;
 ```
 
+### Dynamic PostgreSQL connection parameters
+
+If the information about which database server to connect and how needs to be dynamic,
+it is possible to pass a [custom client configuration](https://node-postgres.com/api/client) in the message:
+
+```js
+msg.pgConfig = {
+  user?: string, // default process.env.PGUSER || process.env.USER
+  password?: string or function, //default process.env.PGPASSWORD
+  host?: string, // default process.env.PGHOST
+  database?: string, // default process.env.PGDATABASE || process.env.USER
+  port?: number, // default process.env.PGPORT
+  connectionString?: string, // e.g. postgres://user:password@host:5432/database
+  ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options
+  types?: any, // custom type parsers
+  statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
+  query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
+  application_name?: string, // The name of the application that created this Client instance
+  connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
+  idle_in_transaction_session_timeout?: number, // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
+};
+```
+
+This does not use a [connection pool](https://node-postgres.com/features/pooling), and is therefore less efficient.
+
 ## Installation
 
 ### Using the Node-RED Editor

--- a/README.md
+++ b/README.md
@@ -70,7 +70,8 @@ msg.pgConfig = {
 };
 ```
 
-This does not use a [connection pool](https://node-postgres.com/features/pooling), and is therefore less efficient.
+However, this does not use a [connection pool](https://node-postgres.com/features/pooling), and is therefore less efficient.
+It is therefore recommended in most cases not to use `msg.pgConfig` at all and instead stick to the built-in configuration node.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ it is possible to pass a [custom client configuration](https://node-postgres.com
 ```js
 msg.pgConfig = {
   user?: string, // default process.env.PGUSER || process.env.USER
-  password?: string or function, //default process.env.PGPASSWORD
+  password?: string, //or function, default process.env.PGPASSWORD
   host?: string, // default process.env.PGHOST
   database?: string, // default process.env.PGDATABASE || process.env.USER
   port?: number, // default process.env.PGPORT

--- a/locales/en-US/postgresql.html
+++ b/locales/en-US/postgresql.html
@@ -39,6 +39,31 @@ msg.params = [ msg.id ];
 SELECT * FROM table WHERE id = $1
 </pre>
 
+	<h4>Dynamic PostgreSQL connection parameters</h4>
+	<p>
+		If the information about which database server to connect and how needs to be dynamic,
+		it is possible to pass a <a href="https://node-postgres.com/api/client">custom client configuration</a> in the message:
+	</p>
+		
+<pre>
+msg.pgConfig = {
+	user?: string, // default process.env.PGUSER || process.env.USER
+	password?: string or function, //default process.env.PGPASSWORD
+	host?: string, // default process.env.PGHOST
+	database?: string, // default process.env.PGDATABASE || process.env.USER
+	port?: number, // default process.env.PGPORT
+	connectionString?: string, // e.g. postgres://user:password@host:5432/database
+	ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options
+	types?: any, // custom type parsers
+	statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
+	query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
+	application_name?: string, // The name of the application that created this Client instance
+	connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
+	idle_in_transaction_session_timeout?: number, // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
+};
+</pre>
+	<p>This does not use a <a href="https://node-postgres.com/features/pooling">connection pool</a>, and is therefore less efficient.</p>
+
 	<h3>Backpressure</h3>
 	<p>
 		This node supports <em>backpressure</em> / <em>flow control</em>:

--- a/locales/en-US/postgresql.html
+++ b/locales/en-US/postgresql.html
@@ -62,7 +62,10 @@ msg.pgConfig = {
   idle_in_transaction_session_timeout?: number, // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
 };
 </pre>
-	<p>This does not use a <a href="https://node-postgres.com/features/pooling">connection pool</a>, and is therefore less efficient.</p>
+	<p>
+		However, this does not use a <a href="https://node-postgres.com/features/pooling">connection pool</a>, and is therefore less efficient.
+		It is therefore recommended in most cases not to use `msg.pgConfig` at all and instead stick to the built-in configuration node.
+	</p>
 
 	<h3>Backpressure</h3>
 	<p>

--- a/locales/en-US/postgresql.html
+++ b/locales/en-US/postgresql.html
@@ -47,19 +47,19 @@ SELECT * FROM table WHERE id = $1
 		
 <pre>
 msg.pgConfig = {
-	user?: string, // default process.env.PGUSER || process.env.USER
-	password?: string or function, //default process.env.PGPASSWORD
-	host?: string, // default process.env.PGHOST
-	database?: string, // default process.env.PGDATABASE || process.env.USER
-	port?: number, // default process.env.PGPORT
-	connectionString?: string, // e.g. postgres://user:password@host:5432/database
-	ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options
-	types?: any, // custom type parsers
-	statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
-	query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
-	application_name?: string, // The name of the application that created this Client instance
-	connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
-	idle_in_transaction_session_timeout?: number, // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
+  user?: string, // default process.env.PGUSER || process.env.USER
+  password?: string, //or function, default process.env.PGPASSWORD
+  host?: string, // default process.env.PGHOST
+  database?: string, // default process.env.PGDATABASE || process.env.USER
+  port?: number, // default process.env.PGPORT
+  connectionString?: string, // e.g. postgres://user:password@host:5432/database
+  ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options
+  types?: any, // custom type parsers
+  statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
+  query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
+  application_name?: string, // The name of the application that created this Client instance
+  connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
+  idle_in_transaction_session_timeout?: number, // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
 };
 </pre>
 	<p>This does not use a <a href="https://node-postgres.com/features/pooling">connection pool</a>, and is therefore less efficient.</p>


### PR DESCRIPTION
#fix https://github.com/alexandrainst/node-red-contrib-postgresql/issues/7

### Dynamic PostgreSQL connection parameters

If the information about which database server to connect and how needs to be dynamic,
it is possible to pass a [custom client configuration](https://node-postgres.com/api/client) in the message:

```js
msg.pgConfig = {
  user?: string, // default process.env.PGUSER || process.env.USER
  password?: string or function, //default process.env.PGPASSWORD
  host?: string, // default process.env.PGHOST
  database?: string, // default process.env.PGDATABASE || process.env.USER
  port?: number, // default process.env.PGPORT
  connectionString?: string, // e.g. postgres://user:password@host:5432/database
  ssl?: any, // passed directly to node.TLSSocket, supports all tls.connect options
  types?: any, // custom type parsers
  statement_timeout?: number, // number of milliseconds before a statement in query will time out, default is no timeout
  query_timeout?: number, // number of milliseconds before a query call will timeout, default is no timeout
  application_name?: string, // The name of the application that created this Client instance
  connectionTimeoutMillis?: number, // number of milliseconds to wait for connection, default is no timeout
  idle_in_transaction_session_timeout?: number, // number of milliseconds before terminating any session with an open idle transaction, default is no timeout
};
```
This does not use a [connection pool](https://node-postgres.com/features/pooling), and is therefore less efficient.
