### PR TITLE
Minor visual changes

### DIFF
--- a/locales/en-US/postgresql.html
+++ b/locales/en-US/postgresql.html
@@ -28,7 +28,7 @@ SELECT * FROM table WHERE id = '{{{ msg.id }}}'
 </pre>
 
 	<h4>Dynamic SQL queries</h4>
-	<p>As an alternative to using the query template above, this node also accepts an SQL query via the `msg.query` parameter.</p>
+	<p>As an alternative to using the query template above, this node also accepts an SQL query via the <code>msg.query</code> parameter.</p>
 
 	<h4>Parameterized queries</h4>
 	<p>Parameters for parameterized queries can be passed as an array <code>msg.params</code>:</p>
@@ -67,7 +67,7 @@ msg.pgConfig = {
 </pre>
 	<p>
 		However, this does not use a <a href="https://node-postgres.com/features/pooling">connection pool</a>, and is therefore less efficient.
-		It is therefore recommended in most cases not to use `msg.pgConfig` at all and instead stick to the built-in configuration node.
+		It is therefore recommended in most cases not to use <code>msg.pgConfig</code> at all and instead stick to the built-in configuration node.
 	</p>
 
 	<h3>Backpressure</h3>

--- a/postgresql.html
+++ b/postgresql.html
@@ -101,7 +101,6 @@
 	/* global RED:false, $:false */
 	RED.nodes.registerType('postgreSQLConfig', {
 		category: 'config',
-		color: '#336791',
 		defaults: {
 			name: {
 				value: '',
@@ -168,10 +167,7 @@
 			},
 		},
 		label: function () {
-			if (!this.name) {
-				this.name = this.user + '@' + this.host + ':' + this.port + '/' + this.database;
-			}
-			return this.name;
+			return this.name || this.user + '@' + this.host + ':' + this.port + '/' + this.database;
 		},
 		labelStyle: function () {
 			return this.name ? 'node_label_italic' : '';
@@ -293,7 +289,7 @@
 	/* global RED:false, $:false */
 	RED.nodes.registerType('postgresql', {
 		category: 'storage',
-		color: '#336791',
+		color: '#5b85a7',
 		defaults: {
 			name: {
 				value: '',


### PR DESCRIPTION
- Changed color of node background to make the black text be more readable. 5460546a7b90be5070dd4fb551e7bdc5c1378b3f
- Config entry edited the `name` property. This is not the standard way of node red. Added default naming convention instead. 5460546a7b90be5070dd4fb551e7bdc5c1378b3f
- Replaced markdown with html format in en-US docs. 47310f50c66f3e77c0f2c1ffc43aea1874224216