### PR TITLE
allow complex settings for ssl via json

### DIFF
--- a/postgresql.html
+++ b/postgresql.html
@@ -209,7 +209,7 @@
 			});
 			$('#node-config-input-ssl').typedInput({
 				default: 'bool',
-				types: ['bool', 'global', 'env'],
+				types: ['bool', 'global', 'env', 'json'],
 				typeField: $('#node-config-input-sslFieldType'),
 			});
 			$('#node-config-input-user').typedInput({

--- a/postgresql.js
+++ b/postgresql.js
@@ -42,6 +42,7 @@ module.exports = function (RED) {
 			case 'num':
 				return parseInt(value);
 			case 'bool':
+			case 'json':
 				return JSON.parse(value);
 			case 'env':
 				return process.env[value];


### PR DESCRIPTION
Another addition - as pg allows complex [ssl](https://node-postgres.com/features/ssl) settings as well.

With the type allowing json we can define structures like:

```json
{
    "rejectUnauthorized": false,
    "ca": "***",
    "key": "***",
    "cert": "***",
}
```