### PR TITLE
Fixed slow performance due to releasing client from the pool always w…

### DIFF
--- a/postgresql.js
+++ b/postgresql.js
@@ -174,7 +174,7 @@ module.exports = function (RED) {
 					}
 					if (client) {
 						if (client.release) {
-							client.release(true);
+							client.release(isError);
 						} else if (client.end) {
 							await client.end();
 						}


### PR DESCRIPTION
On my AT5IONT-I a simple query like SELECT 1 via this node took ~300 - 700 ms. For comparation mysql node was ~4 - 10 ms. If client release is called with true value then it will be destroyed, effectively the pool is not used.

https://node-postgres.com/api/pool#release-err-error