### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -10,6 +10,8 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3
@@ -21,6 +23,8 @@ jobs:
   publish-npm:
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3


### PR DESCRIPTION
Potential fix for [https://github.com/alexandrainst/node-red-contrib-postgresql/security/code-scanning/3](https://github.com/alexandrainst/node-red-contrib-postgresql/security/code-scanning/3)

To fix the issue, we need to add a `permissions` block to the workflow. Since the `publish-npm` job requires write access to the `contents` for publishing the package, we will explicitly set `contents: write` for this job. For the `build` job, which only runs tests, we will set `contents: read` to minimize permissions.

The `permissions` block will be added at the job level for both `build` and `publish-npm` to ensure each job has the least privileges required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
