### PR TITLE
Store PostgreSQL user and password in Node-RED credentials

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "node-red-contrib-postgresql",
-	"version": "0.15.4",
+	"version": "0.15.5",
 	"description": "Node-RED node for PostgreSQL, supporting parameters, split, back-pressure",
 	"author": {
 		"name": "Alexandre Alapetite",

--- a/postgresql.html
+++ b/postgresql.html
@@ -49,7 +49,6 @@
 					<span data-i18n="postgresql.label.user"></span>
 				</label>
 				<input type="text" id="node-config-input-user" data-i18n="[placeholder]postgresql.placeholder.user" style="width: 80%;" />
-				<input type="hidden" id="node-config-input-userFieldType" />
 			</div>
 			<div class="form-row">
 				<label for="node-config-input-password">
@@ -57,7 +56,6 @@
 					<span data-i18n="postgresql.label.password"></span>
 				</label>
 				<input type="password" id="node-config-input-password" data-i18n="[placeholder]postgresql.placeholder.password" style="width: 80%;" />
-				<input type="hidden" id="node-config-input-passwordFieldType" />
 			</div>
 		</div>
 		<div id="postgresql-config-tab-pool" style="display: none;">
@@ -153,22 +151,13 @@
 			connectionTimeoutFieldType: {
 				value: 'num',
 			},
-			user: {
-				value: '',
-			},
-			userFieldType: {
-				value: 'str',
-			},
-			password: {
-				value: '',
-			},
-			passwordFieldType: {
-				// TODO: https://nodered.org/docs/creating-nodes/credentials
-				value: 'str',
-			},
+		},
+		credentials: {
+			user: { type: 'text' },
+			password: { type: 'password' },
 		},
 		label: function () {
-			return this.name || this.user + '@' + this.host + ':' + this.port + '/' + this.database;
+			return this.name || this.host + ':' + this.port + '/' + this.database;
 		},
 		labelStyle: function () {
 			return this.name ? 'node_label_italic' : '';
@@ -213,17 +202,6 @@
 				types: ['bool', 'global', 'env', 'json'],
 				typeField: $('#node-config-input-sslFieldType'),
 			});
-			$('#node-config-input-user').typedInput({
-				default: 'str',
-				types: ['str', 'global', 'env'],
-				typeField: $('#node-config-input-userFieldType'),
-			});
-			$('#node-config-input-password')
-				.typedInput({
-					default: 'str',
-					types: ['str', 'global', 'env'],
-					typeField: $('#node-config-input-passwordFieldType'),
-				});
 			$('#node-config-input-applicationName').typedInput({
 				default: 'str',
 				types: ['str', 'global', 'env'],
@@ -233,11 +211,6 @@
 				default: 'num',
 				types: ['num', 'global'],
 				typeField: $('#node-config-input-maxFieldType'),
-			});
-			$('#node-config-input-lin').typedInput({
-				default: 'num',
-				types: ['num', 'global'],
-				typeField: $('#node-config-input-linFieldType'),
 			});
 			$('#node-config-input-idle').typedInput({
 				default: 'num',

--- a/postgresql.js
+++ b/postgresql.js
@@ -54,6 +54,7 @@ module.exports = function (RED) {
 	function PostgreSQLConfigNode(n) {
 		const node = this;
 		RED.nodes.createNode(node, n);
+
 		node.name = n.name;
 		node.host = n.host;
 		node.hostFieldType = n.hostFieldType;
@@ -69,16 +70,12 @@ module.exports = function (RED) {
 		node.maxFieldType = n.maxFieldType;
 		node.idle = n.idle;
 		node.idleFieldType = n.idleFieldType;
-		node.user = n.user;
-		node.userFieldType = n.userFieldType;
-		node.password = n.password;
-		node.passwordFieldType = n.passwordFieldType;
 		node.connectionTimeout = n.connectionTimeout;
 		node.connectionTimeoutFieldType = n.connectionTimeoutFieldType;
 
 		this.pgPool = new Pool({
-			user: getField(node, n.userFieldType, n.user),
-			password: getField(node, n.passwordFieldType, n.password),
+			user: node.credentials.user,
+			password: node.credentials.password,
 			host: getField(node, n.hostFieldType, n.host),
 			port: getField(node, n.portFieldType, n.port),
 			database: getField(node, n.databaseFieldType, n.database),
@@ -88,12 +85,18 @@ module.exports = function (RED) {
 			idleTimeoutMillis: getField(node, n.idleFieldType, n.idle),
 			connectionTimeoutMillis: getField(node, n.connectionTimeoutFieldType, n.connectionTimeout),
 		});
+
 		this.pgPool.on('error', (err, _) => {
 			node.error(err.message);
 		});
 	}
 
-	RED.nodes.registerType('postgreSQLConfig', PostgreSQLConfigNode);
+	RED.nodes.registerType('postgreSQLConfig', PostgreSQLConfigNode, {
+		credentials: {
+			user: { type: 'text' },
+			password: { type: 'password' },
+		},
+	});
 
 	function PostgreSQLNode(config) {
 		const node = this;


### PR DESCRIPTION
This updates the PostgreSQL config node to store user and password in Node-RED credentials instead of regular flow properties.

Note that this removes the Env/Global options for providing user and password. 